### PR TITLE
Fix event emitter MaxListeners warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ const bot = new Client({
   ]
 });
 
+// Increase the maximum number of listeners to avoid MaxListenersExceededWarning
+bot.setMaxListeners(20);
+
 /*bot.player = new Player.Player(bot, {
   leaveOnEnd: true,
   leaveOnEmpty: true,


### PR DESCRIPTION
## Summary
- Increase listener limit on Discord client to prevent MaxListenersExceeded warnings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b23493406c832ab18c9bec84c7bac9