### PR TITLE
Increase listener limit to prevent warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 require('dotenv').config();
+// Augmente la limite globale d'écouteurs pour éviter les avertissements
+const { EventEmitter } = require('events');
+EventEmitter.defaultMaxListeners = 20;
+
 //const Player = require("discord-player")
 const loadCommands = require("./Loaders/loadCommands")
 const loadEvents = require("./Loaders/loadEvents")
@@ -47,6 +51,9 @@ const bot = new Client({
     GatewayIntentBits.MessageContent,
   ]
 });
+
+// Augmente la limite d'écouteurs du client pour éviter l'avertissement MaxListenersExceededWarning
+bot.setMaxListeners(20);
 
 /*bot.player = new Player.Player(bot, {
   leaveOnEnd: true,


### PR DESCRIPTION
## Summary
- raise default Node.js `EventEmitter` listener limit to 20
- set Discord client's listener limit to 20 to avoid MaxListenersExceededWarning

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b23493406c832ab18c9bec84c7bac9