### PR TITLE
Aggregate interactionCreate event handlers

### DIFF
--- a/Events/interactionCreate.js
+++ b/Events/interactionCreate.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const handlersDir = path.join(__dirname, 'interactionCreate');
+const handlers = [];
+
+const loadHandlers = dir => {
+  for (const file of fs.readdirSync(dir)) {
+    const fullPath = path.join(dir, file);
+    const stat = fs.lstatSync(fullPath);
+    if (stat.isDirectory()) {
+      loadHandlers(fullPath);
+    } else if (file === 'interactionCreate.js') {
+      handlers.push(require(fullPath));
+    }
+  }
+};
+
+if (fs.existsSync(handlersDir)) {
+  loadHandlers(handlersDir);
+}
+
+module.exports = async (bot, interaction) => {
+  for (const handler of handlers) {
+    await handler(bot, interaction);
+  }
+};

--- a/Loaders/loadEvents.js
+++ b/Loaders/loadEvents.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 module.exports = (bot) => {
   const eventsDir = path.join(__dirname, '..', 'Events');
-  const disabledFolderName = 'Désactivés'; // Nom du dossier à ignorer
+  const ignoredFolderNames = ['Désactivés', 'interactionCreate'];
   const handlers = {};
 
   const loadEventFiles = (dir, parentFolderName = '') => {
@@ -12,8 +12,7 @@ module.exports = (bot) => {
       const filePath = path.join(dir, file);
       const stat = fs.lstatSync(filePath);
       if (stat.isDirectory()) {
-        // Vérifie si le dossier est "Désactivés", si c'est le cas, passe à l'itération suivante
-        if (file === disabledFolderName) continue;
+        if (ignoredFolderNames.includes(file)) continue;
 
         const folderName = path.basename(filePath);
         const newParentFolderName = parentFolderName


### PR DESCRIPTION
## Summary
- load interactionCreate event once and aggregate sub-handlers
- skip interactionCreate subdirectory when loading events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b252f0477c832a8176c6e451a1cd05